### PR TITLE
Bugfix_v1_0_1_product

### DIFF
--- a/DiginGridTariffAPI.v1_0.json
+++ b/DiginGridTariffAPI.v1_0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Digin Grid Tariff API",
     "description": "Provides grid tariffs. For external and internal use. https://github.com/digin-energi/API-nettleie-for-styring",
-    "version": "1.0",
+    "version": "1.0.1",
     "contact": {
       "name": "Digin Grid Tariff API",
       "url": "https://github.com/digin-energi/API-nettleie-for-styring"
@@ -127,9 +127,18 @@
         "parameters": [
           {
             "name": "TariffKey",
-            "description": "TariffKey dictates which tariff will be queried",
+            "description": "TariffKey dictates which tariff will be queried. Exclusive OR with Product.",
             "in": "query",
-            "required": true,
+            "schema": {
+              "maxLength": 100,
+              "minLength": 0,
+              "type": "string"
+            }
+          },
+          {
+            "name": "Product",
+            "description": "Internal product code or name to be used internally at the grid company. Exclusive OR with TariffKey.",
+            "in": "query",
             "schema": {
               "maxLength": 100,
               "minLength": 0,

--- a/README.md
+++ b/README.md
@@ -281,3 +281,7 @@ Input with range parameter: https://github.com/digin-energi/API-nettleie-for-sty
 <br/>
 Input with startTime and endTime parameters: https://github.com/digin-energi/API-nettleie-for-styring/blob/main/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_input_example_startTime_endTime.json
 <br/>
+
+## 11. Endringslogg:
+22.12.2021 Versjon 1.0.1: DiginGridTariffAPI.v1_0: Lagt til input parameter Product(for internt bruk for nettselskap) som er Exclusive OR med TariffKey. TariffKey ikke lenger definert required.
+<br/>


### PR DESCRIPTION
DiginGridTariffAPI.v1_0.json:
Added Product(for internal grid company use) as input to tariffquery.
Changed TariffKey to be non-required.
Description updated for TariffKey and Product: "Exclusive OR with TariffKey/Product".
Changed version from 1.0 to 1.0.1.
README: Added chapter 11. Endringslogg