### PR TITLE
Version 1.0.2 bugfixes

### DIFF
--- a/DiginGridTariffAPI.v1_0.json
+++ b/DiginGridTariffAPI.v1_0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Digin Grid Tariff API",
     "description": "Provides grid tariffs. For external and internal use. https://github.com/digin-energi/API-nettleie-for-styring",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "contact": {
       "name": "Digin Grid Tariff API",
       "url": "https://github.com/digin-energi/API-nettleie-for-styring"
@@ -147,7 +147,7 @@
           },
           {
             "name": "Range",
-            "description": "Range dictates which day to query, valid values is yesterday,today,tomorrow",
+            "description": "Range dictates which day to query, valid values is yesterday,today,tomorrow. Exclusive OR with startTime/endTime. Yesterday = hour 0 through hour 23 yesterday etc.",
             "in": "query",
             "schema": {
               "maxLength": 10,
@@ -160,7 +160,7 @@
           {
             "name": "StartTime",
             "in": "query",
-            "description": "StartTime/EndTime dictates which timeperiod to query.",
+            "description": "Start DateTime/End DateTime dictates which timeperiod to query. Exclusive OR with range. Example 2021-09-17T00:00:00+02:00",
             "schema": {
               "type": "string",
               "format": "date-time",
@@ -170,7 +170,7 @@
           {
             "name": "EndTime",
             "in": "query",
-            "description": "StartTime/EndTime dictates which timeperiod to query.",
+            "description": "Start DateTime/End DateTime dictates which timeperiod to query. Exclusive OR with range. Example 2021-09-18T00:00:00+02:00",
             "schema": {
               "type": "string",
               "format": "date-time",

--- a/README.md
+++ b/README.md
@@ -283,5 +283,18 @@ Input with startTime and endTime parameters: https://github.com/digin-energi/API
 <br/>
 
 ## 11. Endringslogg:
-22.12.2021 Versjon 1.0.1: DiginGridTariffAPI.v1_0: Lagt til input parameter Product(for internt bruk for nettselskap) som er Exclusive OR med TariffKey. TariffKey ikke lenger definert required.
+22.12.2021: Versjon 1.0.1:<br/>
+<ul>
+  <li> DiginGridTariffAPI.v1_0: Lagt til input parameter Product(for internt bruk for nettselskap) som er Exclusive OR med TariffKey. TariffKey ikke lenger definert required.</li><br/>
+</ul>
+26.01.2022: Versjon 1.0.2:<br/> 
+<ul>
+  <li>DiginGridTariffAPI.v1_0.json:</li>
+  Endret description for StartTime, EndTime og Range i tag TariffQuery.<br/>
+  <br/>
+  <li>gridtariffapi.v1_0.common.schema.json og alle eksempelfiler:</li>
+  Endret MeteringPointsAndPriceLevels til å inneholde currentFixedPriceLevel og meteringPoints, for å koble lastUpdated til meteringPoints og ikke currentFixedPriceLevel.<br/>
+  Endret CurrentFixedPriceLevel.levelId.description og MeteringPointDetails.lastUpdated.description.<br/>
+  Endret FixedPrices.pricelevel til FixedPrices.pricelevels og fra PowerPrices.pricelevel til PowerPrices.pricelevels.<br/>
+</ul>
 <br/>

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_HSDN_example1.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_HSDN_example1.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000003",
           "title": "Nettleie høyspent dn",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -283,7 +283,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": null,
@@ -334,7 +334,7 @@
                 "id": "f122e3e7-3e0c-43ca-a3ce-051ec0339b98",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "c87bfdc8-a73c-4c93-9a3b-b2558b4aa3c4",
                     "valueMin": null,
@@ -412,10 +412,26 @@
       },
       "meteringPointsAndPriceLevels": [
         {
-          "meteringPointIds": [
-            "707057500000000007",
-            "707057500000000008",
-            "707057500000000009"
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000012",
+              "levelValue": null,
+              "lastUpdated": null
+            },
+            {
+              "meteringPointId": "707057500000000013",
+              "levelValue": null,
+              "lastUpdated": null
+            },
+            {
+              "meteringPointId": "707057500000000014",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         }
       ]

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_LSDN_example1.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_LSDN_example1.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000003",
           "title": "Nettleie lavspent dn",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -283,7 +283,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": null,
@@ -334,7 +334,7 @@
                 "id": "f122e3e7-3e0c-43ca-a3ce-051ec0339b98",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "c87bfdc8-a73c-4c93-9a3b-b2558b4aa3c4",
                     "valueMin": null,
@@ -412,10 +412,16 @@
       },
       "meteringPointsAndPriceLevels": [
         {
-          "meteringPointIds": [
-            "707057500000000007",
-            "707057500000000008",
-            "707057500000000009"
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000000",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         }
       ]

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_LSDN_example2.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_LSDN_example2.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000003",
           "title": "Nettleie lavspent dn diff effektledd",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -283,7 +283,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": null,
@@ -334,7 +334,7 @@
                 "id": "f122e3e7-3e0c-43ca-a3ce-051ec0339b98",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "c87bfdc8-a73c-4c93-9a3b-b2558b4aa3c4",
                     "valueMin": 0,
@@ -466,10 +466,26 @@
       },
       "meteringPointsAndPriceLevels": [
         {
-          "meteringPointIds": [
-            "707057500000000010",
-            "707057500000000011",
-            "707057500000000012"
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000010",
+              "levelValue": null,
+              "lastUpdated": null
+            },
+            {
+              "meteringPointId": "707057500000000011",
+              "levelValue": null,
+              "lastUpdated": null
+            },
+            {
+              "meteringPointId": "707057500000000012",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         }
       ]

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_dailymax_example1.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_dailymax_example1.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000001",
           "title": "Nettleie normal under 100MW",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -227,7 +227,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": 0.0000,
@@ -517,24 +517,45 @@
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": null
           },
-          "meteringPointIds": [
-            "707057500000000004"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000004",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         },
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
           },
-          "meteringPointIds": [
-            "707057500000000005",
-            "707057500000000006"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000005",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T01:00:00+02:00"
+            }
+          ]
+        },
+        {
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000006",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T02:00:00+02:00"
+            },
+            {
+              "meteringPointId": "707057500000000007",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T03:00:00+02:00"
+            }
           ]
         }
       ]

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_fusesize_example1.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_fusesize_example1.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000002",
           "title": "Nettleie normal under 100MW",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -227,7 +227,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": 10.0000,
@@ -602,24 +602,45 @@
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": null
           },
-          "meteringPointIds": [
-            "707057500000000007"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000008",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         },
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
           },
-          "meteringPointIds": [
-            "707057500000000008",
-            "707057500000000009"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000009",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T01:00:00+02:00"
+            }
+          ]
+        },
+        {
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000010",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T02:00:00+02:00"
+            },
+            {
+              "meteringPointId": "707057500000000011",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T03:00:00+02:00"
+            }
           ]
         }
       ]

--- a/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_monthlymax_example1.json
+++ b/doc/DiginGridTariffAPI.v1_0_meteringpointsgridtariffs_json_output_monthlymax_example1.json
@@ -9,7 +9,7 @@
           "companyOrgNo": "900000000",
           "title": "Nettleie normal under 100MW",
           "consumptionFlag": true,
-          "lastUpdated": "2021-11-05T00:00:00+01:00",
+          "lastUpdated": "2021-09-01T00:00:00+02:00",
           "usePublicHolidayPrices": false,
           "useWeekendPrices": false,
           "fixedPriceConfiguration": {
@@ -227,7 +227,7 @@
                 "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
                 "startDate": "2021-09-17",
                 "endDate": "2021-09-17",
-                "priceLevel": [
+                "priceLevels": [
                   {
                     "id": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
                     "valueMin": 0.0000,
@@ -517,24 +517,45 @@
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": null
           },
-          "meteringPointIds": [
-            "707057500000000001"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000000",
+              "levelValue": null,
+              "lastUpdated": null
+            }
           ]
         },
         {
           "currentFixedPriceLevel": {
             "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d",
-            "levelValue": null,
-            "lastUpdated": "2021-11-05T01:00:00+01:00"
+            "levelId": "edcf53ce-70d3-4fa0-8bfb-e79918335ab7"
           },
-          "meteringPointIds": [
-            "707057500000000002",
-            "707057500000000003"
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000001",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T01:00:00+02:00"
+            }
+          ]
+        },
+        {
+          "currentFixedPriceLevel": {
+            "id": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
+            "levelId": "4e3de6a7-e1ed-4156-9b1e-04f924609b7d"
+          },
+          "meteringPoints": [
+            {
+              "meteringPointId": "707057500000000002",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T02:00:00+02:00"
+            },
+            {
+              "meteringPointId": "707057500000000003",
+              "levelValue": null,
+              "lastUpdated": "2021-09-17T03:00:00+02:00"
+            }
           ]
         }
       ]

--- a/gridtariffapi.v1_0.common.schema.json
+++ b/gridtariffapi.v1_0.common.schema.json
@@ -54,15 +54,15 @@
     "additionalProperties": false
   },
   "MeteringPointsAndPriceLevels": {
-    "description": "The response object with the grid tariff object and the meteringpointid object",
+    "description": "The response object with the currentFixedPriceLevel object and the meteringPoints object. currentFixedPriceLevel is omitted: if time of the api call is outside of the request timespan (timeNow < StartTime or timeNow > EndTime). This is due to the connection between meteringPoint and tariff is only instant.",
     "type": "object",
     "properties": {
       "currentFixedPriceLevel": {
         "$ref": "gridtariffapi.v1_0.common.schema.json#/CurrentFixedPriceLevel",
         "nullable": true
       },
-      "meteringPointIds": {
-        "$ref": "gridtariffapi.v1_0.common.schema.json#/MeteringPointIds"
+      "meteringPoints": {
+        "$ref": "gridtariffapi.v1_0.common.schema.json#/MeteringPoints"
       }
     },
     "additionalProperties": false
@@ -247,7 +247,7 @@
             "type": "string"
           },
           "hourId": {
-            "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.fixedPrices.priceLevel.hourPrices.id Ex. a4afa37ae2ec41048e2b5153c35af1c5",
+            "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.fixedPrices.priceLevels.hourPrices.id Ex. a4afa37ae2ec41048e2b5153c35af1c5",
             "type": "string"
           }
         },
@@ -262,7 +262,7 @@
             "type": "string"
           },
           "hourId": {
-            "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.powerPrices.priceLevel.hourPrices.id Ex. 27134fc2-514d-479e-aedb-f13fc4f087d1",
+            "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.powerPrices.priceLevels.hourPrices.id Ex. 27134fc2-514d-479e-aedb-f13fc4f087d1",
             "type": "string"
           }
         },
@@ -343,7 +343,7 @@
         "format": "date",
         "nullable": true
       },
-      "priceLevel": {
+      "priceLevels": {
         "type": "array",
         "items": {
           "$ref": "gridtariffapi.v1_0.common.schema.json#/FixedPriceLevel"
@@ -372,7 +372,7 @@
         "format": "date",
         "nullable": true
       },
-      "priceLevel": {
+      "priceLevels": {
         "type": "array",
         "items": {
           "$ref": "gridtariffapi.v1_0.common.schema.json#/PowerPriceLevel"
@@ -715,7 +715,7 @@
     "additionalProperties": false
   },
   "CurrentFixedPriceLevel": {
-    "description": "The last known fixed price level the MPID is placed in based on fuse size or max hour measurement",
+    "description": "The last known fixed price level the meteringPoint is placed in for FixedPriceConfiguration.basis = monthlymax/dailymax (based on max hours). For fusesize it is based on the fusesize. CurrentFixedPriceLevel is omitted: if time of the api call is outside of the request timespan (timeNow < StartTime or timeNow > EndTime). This is due to the connection between meteringPoint and tariff is only instant.",
     "type": "object",
     "properties": {
       "id": {
@@ -723,7 +723,27 @@
         "type": "string"
       },
       "levelId": {
-        "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.fixedPrices.priceLevel.id. Ex. edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
+        "description": "Unique id referencing gridTariffCollections.gridTariff.tariffPrice.priceInfo.fixedPrices.priceLevels.id. Null: if FixedPriceConfiguration.basis = monthlymax|dailymax and no consumption calculation done so far this month. Ex. edcf53ce-70d3-4fa0-8bfb-e79918335ab7",
+        "type": "string",
+        "nullable": true
+      }
+    },
+    "additionalProperties": false
+  },
+  "MeteringPoints": {
+    "description": "List of meteringpoints connected to this grid tariff at the time of the api call.",
+    "type": "array",
+    "items": {
+      "$ref": "gridtariffapi.v1_0.common.schema.json#/MeteringPointDetails"
+    },
+    "nullable": true
+  },
+  "MeteringPointDetails": {
+    "description": "Definition of meteringPointId and levelValue/lastUpdated for fixed price level",
+    "type": "object",
+    "properties": {
+      "meteringPointId": {
+        "description": "meteringPointId. Ex. 707057500000000001",
         "type": "string"
       },
       "levelValue": {
@@ -733,20 +753,12 @@
         "nullable": true
       },
       "lastUpdated": {
-        "description": "Time of when the last metervalues were received from the meters to calculate basis for the fixed level. Ex. 2021-09-17T02:00:00+02:00",
+        "description": "The end time(hour) of the last calculated hour consumption(based on meter reading or estimation) this month. Null if FixedPriceConfiguration.basis = fixed. Ex. 2021-09-17T02:00:00+02:00",
         "type": "string",
         "format": "date-time",
         "nullable": true
       }
     },
     "additionalProperties": false
-  },
-  "MeteringPointIds": {
-    "description": "List of meteringpoint-ids that has this tariff type at the time of the api call. Ex. 707057500000000002",
-    "type": "array",
-    "items": {
-      "type": "string"
-    },
-    "nullable": true
   }
 }


### PR DESCRIPTION
DiginGridTariffAPI.v1_0.json: Changed description for StartTime, EndTime and Range in tag TariffQuery.

gridtariffapi.v1_0.common.schema.json and all example files:
Changed MeteringPointsAndPriceLevels to contain currentFixedPriceLevel and meteringPoints, to attach lastUpdated to meteringPoints and not currentFixedPriceLevel.
Changed CurrentFixedPriceLevel.levelId.description and MeteringPointDetails.lastUpdated.description.
Changed FixedPrices.pricelevel to FixedPrices.pricelevels and changed PowerPrices.pricelevel to PowerPrices.pricelevels to reflect that they are arrays.